### PR TITLE
fix:allow workshop 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ovos-utils >= 0.1.0
 ovos-bus-client>=0.0.9
-ovos-workshop>=0.0.16,<3.0.0
+ovos-workshop>=0.0.16,<4.0.0
 tutubo>=2.0.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `ovos-workshop` package to allow compatibility with a wider range of versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->